### PR TITLE
Add blackout and flashlight effect

### DIFF
--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -115,10 +115,10 @@ class HighScores:
 
         # Only show Back button if comming from start screen
         if self.from_start_screen:
-            back_button = pygame.Rect(200, 540, 200, 40)  # Adjusted back button position
+            back_button = pygame.Rect(200, 500, 200, 40)  # Adjusted back button position
             pygame.draw.rect(screen, (255, 255, 255), back_button, 2)
             back_text = font.render('Back', True, (255, 255, 255))
-            back_text_center = back_text.get_rect(center=(screen.get_width() // 2, 560))
+            back_text_center = back_text.get_rect(center=(screen.get_width() // 2, 520))
             screen.blit(back_text, back_text_center)
 
         pygame.display.flip()
@@ -212,11 +212,13 @@ class GameState:
         self.ctrl_pressed = False  # To keep track of left CTRL if searching
 
 class StartScreen:
-    def __init__(self, screen, game_state, high_scores):
+    def __init__(self, screen, game_state, high_scores, board):
         self.screen = screen
         self.game_state = game_state
         self.high_scores = high_scores
+        self.board = board
         self.tutorial_checked = False
+        self.lights_checked = False  # New attribute for lights checkbox
         self.selected_level = 0
         self.show_high_scores = False
         self.dropdown_open = False
@@ -247,7 +249,47 @@ class StartScreen:
         dropdown_button = pygame.Rect(200, 190, 200, 40)  # Adjusted dropdown button position
         pygame.draw.rect(self.screen, (255, 255, 255), dropdown_button, 2)
 
-        # Draw the dropdown menu as a single frame/box
+        # Display the selected level
+        if self.tutorial_checked:
+            selected_level_text = dropdown_font.render(f'Tutorial {self.selected_level + 1}', True, (255, 255, 255))
+        else:
+            selected_level_text = dropdown_font.render(f'Level {self.selected_level + 1}', True, (255, 255, 255))
+        selected_level_text_center = selected_level_text.get_rect(center=(self.screen.get_width() // 2, 210))
+        self.screen.blit(selected_level_text, selected_level_text_center)
+
+        # Lights checkbox
+        lights_text = font.render('Lights OFF', True, (255, 255, 255))
+        lights_check = pygame.Rect(self.screen.get_width() // 2 + 65, 356, 25, 25)  # Centered position
+        pygame.draw.rect(self.screen, (255, 255, 255), lights_check, 2)
+        if self.lights_checked:
+            # Draw the "X" mark inside the checkbox
+            pygame.draw.line(self.screen, (255, 255, 255), (self.screen.get_width() // 2 + 70, 360), (self.screen.get_width() // 2 + 84, 375), 2)
+            pygame.draw.line(self.screen, (255, 255, 255), (self.screen.get_width() // 2 + 84, 360), (self.screen.get_width() // 2 + 70, 375), 2)
+        lights_text_center = lights_text.get_rect(center=(278, 370))
+        self.screen.blit(lights_text, lights_text_center)
+
+        # Start Game button
+        start_button = pygame.Rect(200, 400, 200, 40)  # Adjusted start button position
+        pygame.draw.rect(self.screen, (255, 255, 255), start_button, 2)
+        start_text = font.render('Start Game', True, (255, 255, 255))
+        start_text_center = start_text.get_rect(center=(self.screen.get_width() // 2, 420))
+        self.screen.blit(start_text, start_text_center)
+
+        # High Scores button
+        high_scores_button = pygame.Rect(200, 450, 200, 40)  # Adjusted high scores button position
+        pygame.draw.rect(self.screen, (255, 255, 255), high_scores_button, 2)
+        high_scores_text = font.render('High Scores', True, (255, 255, 255))
+        high_scores_text_center = high_scores_text.get_rect(center=(self.screen.get_width() // 2, 470))
+        self.screen.blit(high_scores_text, high_scores_text_center)
+
+        # Quit button
+        quit_button = pygame.Rect(200, 500, 200, 40)  # Adjusted quit button position
+        pygame.draw.rect(self.screen, (255, 255, 255), quit_button, 2)
+        quit_text = font.render('Quit', True, (255, 255, 255))
+        quit_text_center = quit_text.get_rect(center=(self.screen.get_width() // 2, 520))
+        self.screen.blit(quit_text, quit_text_center)
+
+        # Draw the dropdown menu last if it is open
         if self.dropdown_open:
             levels = ['Tutorial 1', 'Tutorial 2', 'Tutorial 3', 'Tutorial 4'] if self.tutorial_checked else ['Level 1', 'Level 2', 'Level 3', 'Level 4', 'Level 5']
             dropdown_box = pygame.Rect(200, 250, 200, len(levels) * 32)
@@ -256,39 +298,8 @@ class StartScreen:
                 level_text = dropdown_font.render(level, True, (255, 255, 255))
                 self.screen.blit(level_text, (210, 260 + i * 30))
 
-        # Display the selected level when dropdown is closed
-        if not self.dropdown_open:
-            if self.tutorial_checked:
-                selected_level_text = dropdown_font.render(f'Tutorial {self.selected_level + 1}', True, (255, 255, 255))
-                selected_level_text_center = selected_level_text.get_rect(center=(self.screen.get_width() // 2, 210))
-                self.screen.blit(selected_level_text, selected_level_text_center)
-            else:
-                selected_level_text = dropdown_font.render(f'Level {self.selected_level + 1}', True, (255, 255, 255))
-                selected_level_text_center = selected_level_text.get_rect(center=(self.screen.get_width() // 2, 210))
-                self.screen.blit(selected_level_text, selected_level_text_center)
-
-        # Start Game button
-        start_button = pygame.Rect(200, 440, 200, 40)  # Adjusted start button position
-        pygame.draw.rect(self.screen, (255, 255, 255), start_button, 2)
-        start_text = font.render('Start Game', True, (255, 255, 255))
-        start_text_center = start_text.get_rect(center=(self.screen.get_width() // 2, 460))
-        self.screen.blit(start_text, start_text_center)
-
-        # High Scores button
-        high_scores_button = pygame.Rect(200, 490, 200, 40)  # Adjusted high scores button position
-        pygame.draw.rect(self.screen, (255, 255, 255), high_scores_button, 2)
-        high_scores_text = font.render('High Scores', True, (255, 255, 255))
-        high_scores_text_center = high_scores_text.get_rect(center=(self.screen.get_width() // 2, 510))
-        self.screen.blit(high_scores_text, high_scores_text_center)
-
-        # Quit button
-        quit_button = pygame.Rect(200, 540, 200, 40)  # Adjusted quit button position
-        pygame.draw.rect(self.screen, (255, 255, 255), quit_button, 2)
-        quit_text = font.render('Quit', True, (255, 255, 255))
-        quit_text_center = quit_text.get_rect(center=(self.screen.get_width() // 2, 560))
-        self.screen.blit(quit_text, quit_text_center)
-
         pygame.display.flip()
+
 
     def handle_events(self):
         # Handle user interactions on the start screen
@@ -312,8 +323,14 @@ class StartScreen:
                     if level_index < levels:
                         self.selected_level = level_index
                         self.dropdown_open = False
+               # Toggle lights checkbox
+                elif self.screen.get_width() // 2 + 65 <= mouse_pos[0] <= self.screen.get_width() // 2 + 90 and 356 <= mouse_pos[1] <= 381:
+                    self.lights_checked = not self.lights_checked
+                    self.board.blackout = not self.board.blackout
+                    print(f"Light toggled: {'OFF' if self.board.blackout else 'ON'}")  # Debug statement
+                    self.draw()  # Redraw to update checkbox
                 # Start the game
-                elif 200 <= mouse_pos[0] <= 400 and 450 <= mouse_pos[1] <= 490:
+                elif 200 <= mouse_pos[0] <= 400 and 410 <= mouse_pos[1] <= 450:
                     self.game_state.game = not self.tutorial_checked
                     self.game_state.current_level = self.selected_level
                     self.game_state.is_playing = True
@@ -323,14 +340,15 @@ class StartScreen:
                     self.game_state.lives = 3
                     return 'start_game'
                 # Show high scores
-                elif 200 <= mouse_pos[0] <= 400 and 500 <= mouse_pos[1] <= 540:
+                elif 200 <= mouse_pos[0] <= 400 and 460 <= mouse_pos[1] <= 500:
                     self.show_high_scores = True
                     return 'show_high_scores'
                 # Quit the game
-                elif 200 <= mouse_pos[0] <= 400 and 550 <= mouse_pos[1] <= 590:
+                elif 200 <= mouse_pos[0] <= 400 and 510 <= mouse_pos[1] <= 550:
                     pygame.quit()
                     sys.exit()
         return None
+
 
 def check_level_complete(board, game_state):
     # Check if the current level is complete
@@ -710,7 +728,7 @@ def main():
     audio = AudioManager()
     high_scores = HighScores()
     screen = pygame.display.set_mode((600, 600))
-    start_screen = StartScreen(screen, game_state, high_scores)
+    start_screen = StartScreen(screen, game_state, high_scores, board)
 
     clock = pygame.time.Clock()
     show_start_screen = True
@@ -737,7 +755,7 @@ def main():
                         # Back to start screen
                         elif event.type == pygame.MOUSEBUTTONDOWN:
                             mouse_pos = pygame.mouse.get_pos()
-                            if 150 <= mouse_pos[0] <= 350 and 550 <= mouse_pos[1] <= 590:
+                            if 150 <= mouse_pos[0] <= 350 and 510 <= mouse_pos[1] <= 550:
                                 start_screen.show_high_scores = False
                                 start_screen.draw()
         else:

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 try:
     pygame.mixer.pre_init(44100, -16, 1, 2048)
     pygame.init()
+
     # Create font objects
+    tutorial_font = pygame.font.SysFont('Lucida Console', 12)  # Font for tutorial text
     font = pygame.font.SysFont('Lucida Console', 24)  # Font for UI text
     dropdown_font = pygame.font.SysFont('Lucida Console', 20)  # Smaller font for dropdown
     hig_score_font = pygame.font.SysFont('Arial Black', 32)  # Bigger font for High Scores
@@ -26,7 +28,7 @@ except pygame.error as e:
 # Game constants
 ANIMATION_SPEED = 17
 DISTANCE = TILE_SIZE
-MOVEMENT_DELAY = 10 # Controls movement speed (higher = slower)
+MOVEMENT_DELAY = 10  # Controls movement speed (higher = slower)
 
 # # Creates a list of maps from tutorial_maps and game_maps
 # level_map = [tutorial_maps.tutorial_map]
@@ -113,7 +115,7 @@ class HighScores:
             score_center = score_text.get_rect(center=(screen.get_width() // 2, 120 + i * 50))
             screen.blit(score_text, score_center)
 
-        # Only show Back button if comming from start screen
+        # Only show Back button if coming from start screen
         if self.from_start_screen:
             back_button = pygame.Rect(200, 500, 200, 40)  # Adjusted back button position
             pygame.draw.rect(screen, (255, 255, 255), back_button, 2)
@@ -122,7 +124,6 @@ class HighScores:
             screen.blit(back_text, back_text_center)
 
         pygame.display.flip()
-
 
     # Input box for entering initials after achieving a high score
     def get_initials(self, screen):
@@ -300,7 +301,6 @@ class StartScreen:
 
         pygame.display.flip()
 
-
     def handle_events(self):
         # Handle user interactions on the start screen
         for event in pygame.event.get():
@@ -323,7 +323,7 @@ class StartScreen:
                     if level_index < levels:
                         self.selected_level = level_index
                         self.dropdown_open = False
-               # Toggle lights checkbox
+                # Toggle lights checkbox
                 elif self.screen.get_width() // 2 + 65 <= mouse_pos[0] <= self.screen.get_width() // 2 + 90 and 356 <= mouse_pos[1] <= 381:
                     self.lights_checked = not self.lights_checked
                     self.board.blackout = not self.board.blackout
@@ -349,8 +349,7 @@ class StartScreen:
                     sys.exit()
         return None
 
-
-def check_level_complete(board, game_state):
+def check_level_complete(board, game_state, screen, game_board):
     # Check if the current level is complete
     if not board.exit:
         return False
@@ -358,7 +357,7 @@ def check_level_complete(board, game_state):
     # Check if player is on exit tile
     for element in board.elements:
         if element[0] == TileType.EXIT:
-            if (board.px, board.py) == element[1]: # Player position matches exit position
+            if (board.px, board.py) == element[1]:  # Player position matches exit position
                 # Render one last frame with player on exit
                 pygame.display.get_surface().fill((30, 30, 30))
                 board.blit_level(pygame.display.get_surface())
@@ -373,7 +372,21 @@ def check_level_complete(board, game_state):
                     # Add moves to total_moves for high scores
                     game_state.total_moves += game_state.moves
 
-                    pygame.display.set_caption(f'Escape the Werehouse!          Moves: {game_state.moves}          Total Moves: {game_state.total_moves}          Lives: {game_state.lives}     ')
+                    pygame.display.set_caption(f'Escape the Werehouse!')
+
+                    # Draw the status bar at the top
+                    bar_rect = pygame.Rect(0, board.offset_y - board.offset_y, screen.get_width(), board.offset_y)
+                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+
+                    # Render the text inside the bar
+                    moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
+                    total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
+                    lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
+                    game_board.blit(moves_text, (10, 10))
+                    game_board.blit(total_moves_text, (200, 10))
+                    game_board.blit(lives_text, (480, 10))
+
+                    # Blit stars
                     board.blit_stars(pygame.display.get_surface(), game_state.moves)
 
                 pygame.display.flip()
@@ -385,7 +398,7 @@ def check_level_complete(board, game_state):
 
 # Handle keyboard input for player movement
 def handle_input(keys, board, game_state, audio):
-     # Check for cooldown period
+    # Check for cooldown period
     if game_state.reset_cooldown > 0:
         game_state.reset_cooldown -= 1
         return False
@@ -449,7 +462,7 @@ def handle_level_complete(board, game_state, high_scores):
             initials = high_scores.get_initials(pygame.display.get_surface())
             high_scores.add_score(game_state.total_moves, initials)
 
-        print("Displaying high scores...") # Debug statement
+        print("Displaying high scores...")  # Debug statement
         high_scores.display_scores(pygame.display.get_surface())
 
 # Handle movement of player and associated boxes
@@ -473,11 +486,11 @@ def move_player_and_boxes(board, direction, travel, is_dragging, audio, game_sta
     if not is_valid_move(board, new_x, new_y, direction, is_dragging, game_state):
         return False  # Don't move if invalid
 
-     # Check if player falls into pit
+    # Check if player falls into pit
     if check_player_in_pit(board, game_state, new_x, new_y, audio):
         return False  # Movement was valid but player fell
 
-     # Handle box movement
+    # Handle box movement
     if is_dragging:
         # Calculate position behind player
         behind_x = x + (x - new_x)
@@ -537,7 +550,6 @@ def move_player_and_boxes(board, direction, travel, is_dragging, audio, game_sta
 
     return True
 
-# Check if a box has fallen into a pit and update states accordingly
 # Check if a box has fallen into a pit and update states accordingly
 def check_box_in_pit(board, box_num, x, y):
     # Mapping of pit types to their corresponding attributes
@@ -720,14 +732,13 @@ def display_game_over(game_state):
     # Wait for a few seconds before returning to the start screen
     pygame.time.wait(3000)
 
-
 def main():
     # Initialize game components
     game_state = GameState()
     board = BoardElements()
     audio = AudioManager()
     high_scores = HighScores()
-    screen = pygame.display.set_mode((600, 600))
+    screen = pygame.display.set_mode((600, 640))  # Set the screen size to 600x640
     start_screen = StartScreen(screen, game_state, high_scores, board)
 
     clock = pygame.time.Clock()
@@ -744,7 +755,7 @@ def main():
             if action == 'start_game':
                 show_start_screen = False
             elif action == 'show_high_scores':
-                # Set to True to enable Back buttonn
+                # Set to True to enable Back button
                 high_scores.from_start_screen = True
                 high_scores.display_scores(screen)
                 while start_screen.show_high_scores:
@@ -755,12 +766,12 @@ def main():
                         # Back to start screen
                         elif event.type == pygame.MOUSEBUTTONDOWN:
                             mouse_pos = pygame.mouse.get_pos()
-                            if 150 <= mouse_pos[0] <= 350 and 510 <= mouse_pos[1] <= 550:
+                            if 200 <= mouse_pos[0] <= 400 and 500 <= mouse_pos[1] <= 540:
                                 start_screen.show_high_scores = False
                                 start_screen.draw()
         else:
             # Set up game board
-            game_board = pygame.display.set_mode((board.game_board_x, board.game_board_y))
+            game_board = pygame.display.set_mode((board.game_board_x, board.game_board_y + board.offset_y))  # Adjust the height
             game_state.new_level = True  # Reset level to start from the selected one
 
             # Main game loop
@@ -786,7 +797,7 @@ def main():
                     game_state.debounce_timer -= 1
 
                 # Check level completion
-                if check_level_complete(board, game_state):
+                if check_level_complete(board, game_state, screen, game_board):
                     handle_level_complete(board, game_state, high_scores)
                     if not game_state.is_playing:
                         high_scores.from_start_screen = False  # Set the flag to False
@@ -797,10 +808,8 @@ def main():
                 # Set background color
                 game_board.fill((30, 30, 30))
 
-                # Render current level
+                # Render the rest of the game elements
                 board.blit_level(game_board)
-
-                # Render boxes
                 board.blit_box_1(game_board, 0, 0)
                 board.blit_box_2(game_board, 0, 0)
                 board.blit_box_3(game_board, 0, 0)
@@ -817,10 +826,28 @@ def main():
                 # Apply blackout effect
                 board.apply_blackout(game_board, game_state)
 
+                # Draw the status bar at the top
+                bar_rect = pygame.Rect(0, board.offset_y - board.offset_y, screen.get_width(), board.offset_y)
+                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+
+                # Render the text inside the bar
                 if game_state.game:
-                    pygame.display.set_caption(f'Escape the Werehouse!          Moves: {game_state.moves}          Total Moves: {game_state.total_moves}          Lives: {game_state.lives}     ')
+                    moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
+                    total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
+                    lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
+
+                    game_board.blit(moves_text, (10, 10))
+                    game_board.blit(total_moves_text, (200, 10))
+                    game_board.blit(lives_text, (480, 10))
                 else:
-                    pygame.display.set_caption(f'{board.titel[game_state.current_level]}')
+                    tutorial_text = tutorial_font.render(f'{board.map_title[0][game_state.current_level]}', True, (255, 255, 255))
+
+                    game_board.blit(tutorial_text, (15, 15))
+
+                if game_state.game:
+                    pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
+                else:
+                    pygame.display.set_caption(f'Escape the Werehouse! - Tutorial {game_state.current_level + 1}')
 
                 pygame.display.flip()
                 # Cap frame rate

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -209,6 +209,7 @@ class GameState:
         self.debounce_timer = 0  # To avoid unwanted movements
         self.reset_cooldown = 0  # Cooldown timer after level reset
         self.travel = 0  # Only keep track of direction
+        self.ctrl_pressed = False  # To keep track of left CTRL if searching
 
 class StartScreen:
     def __init__(self, screen, game_state, high_scores):
@@ -374,6 +375,9 @@ def handle_input(keys, board, game_state, audio):
     direction = None
     is_dragging = keys[pygame.K_SPACE]
 
+    # Check if left CTRL key is pressed when searching
+    game_state.ctrl_pressed = keys[pygame.K_LCTRL]
+
     # Store previous position for validation
     prev_x = board.px
     prev_y = board.py
@@ -448,7 +452,7 @@ def move_player_and_boxes(board, direction, travel, is_dragging, audio, game_sta
         new_x = x + 100  # Move exactly one tile right
 
     # First check if the move is valid
-    if not is_valid_move(board, new_x, new_y, direction, is_dragging):
+    if not is_valid_move(board, new_x, new_y, direction, is_dragging, game_state):
         return False  # Don't move if invalid
 
      # Check if player falls into pit
@@ -554,8 +558,12 @@ def check_box_in_pit(board, box_num, x, y):
             return False
 
 # Check if move is valid
-def is_valid_move(board, new_x, new_y, direction, is_dragging):
+def is_valid_move(board, new_x, new_y, direction, is_dragging, game_state):
     if new_x < 0 or new_x >= 600 or new_y < 0 or new_y >= 600:
+        return False
+
+    # If left CTRL is pressed, invalidate the move
+    if game_state.ctrl_pressed:
         return False
 
     # Check if the target position contains a valid tile

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -788,6 +788,9 @@ def main():
                 else:
                     board.blit_player(game_board, 0, 0)
 
+                # Apply blackout effect
+                board.apply_blackout(game_board, game_state)
+
                 if game_state.game:
                     pygame.display.set_caption(f'Escape the Werehouse!          Moves: {game_state.moves}          Total Moves: {game_state.total_moves}          Lives: {game_state.lives}     ')
                 else:

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -448,16 +448,20 @@ def handle_level_complete(board, game_state, high_scores):
 
     # Handle mode transitions
     if game_state.game == False and game_state.current_level >= 4:
-        game_state.game = True
-        game_state.current_level = 0
         # Debug statement
         print('Well done, you finished the Tutorials! Now try to Escape the Werehouse!')
+        # Set game states
+        game_state.game = True
+        game_state.current_level = 0
+        game_state.moves = 0
+        game_state.total_moves = 0
+        game_state.lives = 3
     elif game_state.game == True and game_state.current_level >= 5:
-        game_state.is_playing = False
         # Debug statements
         print('Congratulations! You finished the last level!')
         print(f'Your have made a total of {game_state.total_moves} successful moves!')
-
+        # End game
+        game_state.is_playing = False
         if high_scores.is_high_score(game_state.total_moves):
             initials = high_scores.get_initials(pygame.display.get_surface())
             high_scores.add_score(game_state.total_moves, initials)
@@ -830,24 +834,25 @@ def main():
                 bar_rect = pygame.Rect(0, board.offset_y - board.offset_y, screen.get_width(), board.offset_y)
                 pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
 
-                # Render the text inside the bar
+                # Set caption and render the text inside the status bar
                 if game_state.game:
+                    # Set window caption
+                    pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
+                    # Set status bar
                     moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
                     total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
                     lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
-
+                    # Render status bar
                     game_board.blit(moves_text, (10, 10))
                     game_board.blit(total_moves_text, (200, 10))
                     game_board.blit(lives_text, (480, 10))
                 else:
-                    tutorial_text = tutorial_font.render(f'{board.map_title[0][game_state.current_level]}', True, (255, 255, 255))
-
-                    game_board.blit(tutorial_text, (15, 15))
-
-                if game_state.game:
-                    pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
-                else:
+                    # Set window caption
                     pygame.display.set_caption(f'Escape the Werehouse! - Tutorial {game_state.current_level + 1}')
+                    # Set status bar
+                    tutorial_text = tutorial_font.render(f'{board.map_title[0][game_state.current_level]}', True, (255, 255, 255))
+                    # Render status bar
+                    game_board.blit(tutorial_text, (15, 15))
 
                 pygame.display.flip()
                 # Cap frame rate

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -83,7 +83,7 @@ class BoardElements():
         self.lv = 0
 
         # Variable to toggle blackout effect
-        self.blackout = True
+        self.blackout = False
 
         # Default initial beam angle
         self.current_beam_angle = -1.5
@@ -586,7 +586,7 @@ class BoardElements():
             elif game_state.travel == 4:  # RIGHT
                 target_angle = math.atan2(0, 1)
 
-            smoothing_factor = 0.3  # lower is slower rotation.
+            smoothing_factor = 0.2  # lower is slower rotation.
             if target_angle is not None:
                 self.current_beam_angle = self.__lerp_angle__(self.current_beam_angle, target_angle, smoothing_factor)
             direction_angle = self.current_beam_angle

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -13,6 +13,10 @@ tiles = game_maps.tiles
 level_map = [tutorial_maps.tutorial_map]
 level_map.append(game_maps.level_map)
 
+# Creates a list of maps titles from tutorial_maps and game_maps
+map_title = [tutorial_maps.title]
+map_title.append(game_maps.title)
+
 # Creates a list of active boxes from tutorial_maps and game_maps
 active_boxes = [tutorial_maps.active_boxes]
 active_boxes.append(game_maps.active_boxes)
@@ -49,8 +53,8 @@ class BoardElements():
         self.game_board_x = 600
         self.game_board_y = 600
 
-        # List of Tutorial map titles
-        self.titel = tutorial_maps.titel
+        # List of map titles
+        self.map_title = map_title
 
         # Variable to keep track of numbers of Levels
         self.no_of_levels = [sum(type(i) == type([]) for i in level_map[0])]
@@ -87,6 +91,8 @@ class BoardElements():
 
         # Default initial beam angle
         self.current_beam_angle = -1.5
+
+        self.offset_y = 40
 
 
     def update_game_board_size(self, level_map):
@@ -314,33 +320,33 @@ class BoardElements():
         # For each element in list of Level elements
         # - Blit tiles depending on value of Game Board element
         for el in self.elements:
-            # Blit tile cooresponding to value of Game Board element
+            # Blit tile corresponding to value of Game Board element
             if el[0] == 0:
-                self.__start__(game_board, el[1])
+                self.__start__(game_board, (el[1][0], el[1][1] + self.offset_y))
 
             elif el[0] == 1:
-                self.__pit_1__(game_board, el[1], self.in_pit1)
+                self.__pit_1__(game_board, (el[1][0], el[1][1] + self.offset_y), self.in_pit1)
 
             elif el[0] == 2:
-                self.__pit_2__(game_board, el[1], self.in_pit2)
+                self.__pit_2__(game_board, (el[1][0], el[1][1] + self.offset_y), self.in_pit2)
 
             elif el[0] == 3:
-                self.__pit_3__(game_board, el[1], self.in_pit3, el[3])
+                self.__pit_3__(game_board, (el[1][0], el[1][1] + self.offset_y), self.in_pit3, el[3])
 
             elif el[0] == 4:
-                self.__pit_4__(game_board, el[1], self.in_pit4, el[3])
+                self.__pit_4__(game_board, (el[1][0], el[1][1] + self.offset_y), self.in_pit4, el[3])
 
             elif el[0] == 5:
-                self.__pit_as_wall__(game_board, el[1])
+                self.__pit_as_wall__(game_board, (el[1][0], el[1][1] + self.offset_y))
 
             elif el[0] == 6:
-                self.__floor__(game_board, el[1], el[2])
+                self.__floor__(game_board, (el[1][0], el[1][1] + self.offset_y), el[2])
 
             elif el[0] == 7:
-                self.__wall__(game_board, el[1])
+                self.__wall__(game_board, (el[1][0], el[1][1] + self.offset_y))
 
             elif el[0] == 8:
-                self.__exit___(game_board, el[1])
+                self.__exit___(game_board, (el[1][0], el[1][1] + self.offset_y))
 
 
     # Setup of new Level
@@ -376,17 +382,17 @@ class BoardElements():
             # If movement is Up or Down
             # - Blit box1 in direction of y corresponding of b1_move' value
             if b1_travel == 1 or b1_travel == 2:
-                game_board.blit(self.box[0][1], (self.b1x, b1_move))
+                game_board.blit(self.box[0][1], (self.b1x, b1_move + self.offset_y))
 
             # Else if movement is Left or Right
             # - Blit box1 in direction of x corresponding of b1_move' value
             elif b1_travel == 3 or b1_travel == 4:
-                game_board.blit(self.box[0][1], (b1_move, self.b1y))
+                game_board.blit(self.box[0][1], (b1_move, self.b1y + self.offset_y))
 
             # Else
             # - Blit position of box1
             else:
-                game_board.blit(self.box[0][1], (self.b1x, self.b1y))
+                game_board.blit(self.box[0][1], (self.b1x, self.b1y + self.offset_y))
 
 
     # Blit box2
@@ -397,17 +403,18 @@ class BoardElements():
             # If movement is Up or Down
             # - Blit box2 in direction of y corresponding of b2_move' value
             if b2_travel == 1 or b2_travel == 2:
-                game_board.blit(self.box[1][1], (self.b2x, b2_move))
+                game_board.blit(self.box[1][1], (self.b2x, b2_move + self.offset_y))
 
             # Else if movement is Left or Right
             # - Blit box2 in direction of x corresponding of b2_move' value
             elif b2_travel == 3 or b2_travel == 4:
-                game_board.blit(self.box[1][1], (b2_move, self.b2y))
+                game_board.blit(self.box[1][1], (b2_move, self.b2y + self.offset_y))
 
             # Else
             # - Blit position of box2
             else:
-                game_board.blit(self.box[1][1], (self.b2x, self.b2y))
+                game_board.blit(self.box[1][1], (self.b2x, self.b2y + self.offset_y))
+
 
 
     # Blit box3
@@ -418,17 +425,18 @@ class BoardElements():
             # If movement is Up or Down
             # - Blit box3 in direction of y corresponding of b3_move' value
             if b3_travel == 1 or b3_travel == 2:
-                game_board.blit(self.box[2][1], (self.b3x, b3_move))
+                game_board.blit(self.box[2][1], (self.b3x, b3_move + self.offset_y))
 
             # Else if movement is Left or Right
             # - Blit box3 in direction of x corresponding of b3_move' value
             elif b3_travel == 3 or b3_travel == 4:
-                game_board.blit(self.box[2][1], (b3_move, self.b3y))
+                game_board.blit(self.box[2][1], (b3_move, self.b3y + self.offset_y))
 
             # Else
             # - Blit position of box3
             else:
-                game_board.blit(self.box[2][1], (self.b3x, self.b3y))
+                game_board.blit(self.box[2][1], (self.b3x, self.b3y + self.offset_y))
+
 
 
     # Blit box4
@@ -439,48 +447,48 @@ class BoardElements():
             # If movement is Up or Down
             # - Blit box4 in direction of y corresponding of b4_move' value
             if b4_travel == 1 or b4_travel == 2:
-                game_board.blit(self.box[3][1], (self.b4x, b4_move))
+                game_board.blit(self.box[3][1], (self.b4x, b4_move + self.offset_y))
 
             # Else if movement is Left or Right
             # - Blit box4 in direction of x corresponding of b4_move' value
             elif b4_travel == 3 or b4_travel == 4:
-                game_board.blit(self.box[3][1], (b4_move, self.b4y))
+                game_board.blit(self.box[3][1], (b4_move, self.b4y + self.offset_y))
 
             # Else
             # - Blit position of box4
             else:
-                game_board.blit(self.box[3][1], (self.b4x, self.b4y))
+                game_board.blit(self.box[3][1], (self.b4x, self.b4y + self.offset_y))
 
 
     # Blit player
     def blit_player(self, game_board, p_travel, p_move):
         '''blit_player'''
-        # If play eqauls True
+        # If play equals True
         if self.play:
             # If movement is Up
             # - Blit player in direction of y corresponding of p_move' value
             if p_travel == 1:
-                game_board.blit(gfx.player_up, (self.px, p_move))
+                game_board.blit(gfx.player_up, (self.px, p_move + self.offset_y))
 
             # Else iff movement is Down
             # - Blit player in direction of y corresponding of p_move' value
             elif p_travel == 2:
-                game_board.blit(gfx.player_down, (self.px, p_move))
+                game_board.blit(gfx.player_down, (self.px, p_move + self.offset_y))
 
             # Else iff movement is Left
             # - Blit player in direction of x corresponding of p_move' value
             elif p_travel == 3:
-                game_board.blit(gfx.player_left, (p_move, self.py))
+                game_board.blit(gfx.player_left, (p_move, self.py + self.offset_y))
 
             # Else iff movement is Right
             # - Blit player in direction of x corresponding of p_move' value
             elif p_travel == 4:
-                game_board.blit(gfx.player_right, (p_move, self.py))
+                game_board.blit(gfx.player_right, (p_move, self.py + self.offset_y))
 
             # Else
             # - Blit position of player
             else:
-                game_board.blit(gfx.player, (self.px, self.py))
+                game_board.blit(gfx.player, (self.px, self.py + self.offset_y))
 
 
     # Blit Game Level score
@@ -490,62 +498,63 @@ class BoardElements():
         if self.lv == 1:
             if moves <= 19:
                 # Blit 3 highlighted Stars
-                game_board.blit(gfx.stars[3], (186, 115))
-    
+                game_board.blit(gfx.stars[3], (186, 155 - self.offset_y))
+
             elif moves > 19 and moves <= 21:
                 # Blit 2 highlighted Stars
-                game_board.blit(gfx.stars[2], (186, 115))
+                game_board.blit(gfx.stars[2], (186, 155 - self.offset_y))
 
             else:
                 # Blit 1 highlighted Star
-                game_board.blit(gfx.stars[1], (186, 115))
+                game_board.blit(gfx.stars[1], (186, 155 - self.offset_y))
 
         # Blit score for LEVEL 2 depending on number of moves
         elif self.lv == 2:
             if moves <= 24:
                 # Blit 3 highlighted Stars
-                game_board.blit(gfx.stars[3], (186, 115))
+                game_board.blit(gfx.stars[3], (186, 155 - self.offset_y))
 
             elif moves > 24 and moves <= 26:
                 # Blit 2 highlighted Stars
-                game_board.blit(gfx.stars[2], (186, 115))
+                game_board.blit(gfx.stars[2], (186, 155 - self.offset_y))
 
             else:
                 # Blit 1 highlighted Star
-                game_board.blit(gfx.stars[1], (186, 115))
+                game_board.blit(gfx.stars[1], (186, 155 - self.offset_y))
 
         # Blit score for LEVEL 3 depending on number of moves
         elif self.lv == 3:
             if moves <= 35:
                 # Blit 3 highlighted Stars
-                game_board.blit(gfx.stars[3], (186, 115))
+                game_board.blit(gfx.stars[3], (186, 155 - self.offset_y))
 
             elif moves > 35 and moves <= 37:
                 # Blit 2 highlighted Stars
-                game_board.blit(gfx.stars[2], (186, 115))
+                game_board.blit(gfx.stars[2], (186, 155 - self.offset_y))
 
             else:
                 # Blit 1 highlighted Star
-                game_board.blit(gfx.stars[1], (186, 115))
+                game_board.blit(gfx.stars[1], (186, 155 - self.offset_y))
 
         # Blit score for LEVEL 4 depending on number of moves
         elif self.lv == 4:
             if moves <= 92:
                 # Blit 3 highlighted Stars
-                game_board.blit(gfx.stars[3], (186, 115))
+                game_board.blit(gfx.stars[3], (186, 155 - self.offset_y))
 
             elif moves > 92 and moves <= 94:
                 # Blit 2 highlighted Stars
-                game_board.blit(gfx.stars[2], (186, 115))
+                game_board.blit(gfx.stars[2], (186, 155 - self.offset_y))
 
             else:
                 # Blit 1 highlighted Star
-                game_board.blit(gfx.stars[1], (186, 115))
+                game_board.blit(gfx.stars[1], (186, 155 - self.offset_y))
 
         # Update all changes to display
         pygame.display.update()
         # Pause for 3 seconds to show Stars
         time.sleep(3)
+
 
     def __lerp_angle__(self, current, target, factor):
         """
@@ -562,17 +571,17 @@ class BoardElements():
         '''
         if self.blackout:
             # Create a mask for the game board with per-pixel alpha.
-            mask = pygame.Surface((self.game_board_x, self.game_board_y), pygame.SRCALPHA)
-            # start with nearly full opacity
+            mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
+            # Start with nearly full opacity
             mask.fill((0, 0, 0, 249))  # Semi-transparent black overlay.
 
             # Flashlight parameters.
             beam_length = int(2 * TILE_SIZE)        # How far the beam extends.
-            beam_angle = math.radians(60)              # Total angular width of the beam (60°)
+            beam_angle = math.radians(60)           # Total angular width of the beam (60°)
 
             # Determine the player's center.
             player_center_x = self.px + (TILE_SIZE // 2)
-            player_center_y = self.py + (TILE_SIZE // 2)
+            player_center_y = self.py + (TILE_SIZE // 2) + self.offset_y  # Add the offset here
             player_center = (player_center_x, player_center_y)
 
             # Determine the new target angle based on game_state.travel.
@@ -586,7 +595,7 @@ class BoardElements():
             elif game_state.travel == 4:  # RIGHT
                 target_angle = math.atan2(0, 1)
 
-            smoothing_factor = 0.2  # lower is slower rotation.
+            smoothing_factor = 0.2  # Lower is slower rotation.
             if target_angle is not None:
                 self.current_beam_angle = self.__lerp_angle__(self.current_beam_angle, target_angle, smoothing_factor)
             direction_angle = self.current_beam_angle

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -86,7 +86,7 @@ class BoardElements():
         self.blackout = True
 
         # Default initial beam angle
-        self.current_beam_angle = 0
+        self.current_beam_angle = -1.5
 
 
     def update_game_board_size(self, level_map):
@@ -564,7 +564,7 @@ class BoardElements():
             # Create a mask for the game board with per-pixel alpha.
             mask = pygame.Surface((self.game_board_x, self.game_board_y), pygame.SRCALPHA)
             # start with nearly full opacity
-            mask.fill((0, 0, 0, 247))  # Semi-transparent black overlay.
+            mask.fill((0, 0, 0, 249))  # Semi-transparent black overlay.
 
             # Flashlight parameters.
             beam_length = int(2 * TILE_SIZE)        # How far the beam extends.
@@ -595,7 +595,7 @@ class BoardElements():
             # build up a series of translucent slices for a gradient edge.
             # The inner slices will be fully transparent out to some fraction of the beam_length,
             # and the outer slices will gradually blend.
-            slices = 30  # Number of slices for transitioning the gradient.
+            slices = 50  # Number of slices for transitioning the gradient.
             inner_ratio = 0.2  # Fraction of the beam that is fully transparent (hard cutout).
             # Loop over slices from inner to outer edge.
             for i in range(slices):

--- a/game_board/maps/game_maps.py
+++ b/game_board/maps/game_maps.py
@@ -81,6 +81,9 @@ WALL = 7
 EXIT = 8
 
 # LEVEL 1
+# Level Title
+title = ['Blocked!']
+
 # Map layout for tiles
 level_map = [[FLOOR, FLOOR, FLOOR, WALL, EXIT, FLOOR,
               PIT1, WALL, WALL, WALL, WALL, FLOOR,
@@ -102,6 +105,9 @@ active_exit = [1]
 
 
 # LEVEL 2
+# Level Title
+title.append('Deceiving Pits')
+
 # Map layout for tiles
 level_map.append([EXIT, FLOOR, FLOOR, FLOOR, FLOOR, PIT_WALL,
                   FLOOR, FLOOR, FLOOR, WALL, FLOOR, PIT_WALL,
@@ -123,6 +129,9 @@ active_exit.append(1)
 
 
 # LEVEL 3
+# Level Title
+title.append('One too Many!')
+
 # Map layout for tiles
 level_map.append([FLOOR, FLOOR, WALL, WALL, WALL, EXIT,
                   FLOOR, FLOOR, FLOOR, FLOOR, PIT2, FLOOR,
@@ -144,6 +153,9 @@ active_exit.append(1)
 
 
 # LEVEL 4
+# Level Title
+title.append('Back and Forth')
+
 # Map layout for tiles
 level_map.append([
     START, WALL, EXIT, PIT3, FLOOR, FLOOR,
@@ -165,6 +177,9 @@ active_exit.append(1)
 
 
 # LEVEL Test 10x10
+# Level Title
+# title.append('Deceiving Pits')
+
 # Map layout for tiles
 # level_map.append([
 #     EXIT, PIT_WALL, FLOOR, PIT4, FLOOR, FLOOR, FLOOR, FLOOR, FLOOR, FLOOR,
@@ -191,6 +206,9 @@ active_exit.append(1)
 
 
 # LEVEL 5
+# Level Title
+title.append('The Circles of Life')
+
 # Map layout for tiles
 level_map.append([
     FLOOR, FLOOR, FLOOR, FLOOR, FLOOR, FLOOR,

--- a/game_board/maps/tutorial_maps.py
+++ b/game_board/maps/tutorial_maps.py
@@ -78,7 +78,7 @@ EXIT = 8
 if gfx.debug:
     # DEBUG LEVEL
     # Tutorial title
-    titel = [' Debugging Mode']
+    title = [' Debugging Mode']
 
     # Map layout for tiles
     tutorial_map = [[FLOOR, FLOOR, FLOOR, FLOOR, FLOOR, EXIT,
@@ -104,7 +104,7 @@ if gfx.debug:
 else:
     # TUTORIAL 1
     # Tutorial title
-    titel = [' Tutorial: Push Box to reach Exit']
+    title = ['Push the Box to reach Exit']
 
     # Map layout for tiles
     tutorial_map = [[WALL, WALL, WALL, WALL, WALL, WALL,
@@ -128,13 +128,13 @@ else:
 
     # TUTORIAL 2
     # Tutorial title
-    titel.append('Tutorial: Pits are DANGEROUS! Push Box into the Pit to be able to cross')
+    title.append('Pits are DANGEROUS! Push the Box into the Pit to be able to cross')
 
     # Map layout for tiles
     tutorial_map.append([WALL, WALL, WALL, WALL, WALL, WALL,
-                         WALL, PIT_WALL, PIT1, EXIT, WALL, WALL,
-                         WALL, PIT_WALL, FLOOR, WALL, WALL, WALL,
-                         WALL, PIT_WALL, FLOOR, WALL, WALL, WALL,
+                         WALL, PIT4, PIT1, EXIT, WALL, WALL,
+                         WALL, PIT3, FLOOR, WALL, WALL, WALL,
+                         WALL, PIT2, FLOOR, WALL, WALL, WALL,
                          WALL, WALL, START, WALL, WALL, WALL,
                          WALL, WALL, WALL, WALL, WALL, WALL])
 
@@ -152,7 +152,7 @@ else:
 
     # TUTORIAL 3
     # Tutorial title
-    titel.append('Tutorial: Two Boxes in a row cannot be pushed')
+    title.append('Two Boxes in a row cannot be pushed')
 
     # Map layout for tiles
     tutorial_map.append([WALL, WALL, FLOOR, WALL, WALL, WALL,
@@ -176,7 +176,7 @@ else:
 
     # TUTORIAL 4
     # Tutorial title
-    titel.append('Tutorial: To drag Box stand close to it, hold space bar while moving away from Box')
+    title.append('To pull a Box stand close to it, hold space bar while moving away from the Box')
 
     # Map layout for tiles
     tutorial_map.append([WALL, WALL, WALL, EXIT, WALL, WALL,


### PR DESCRIPTION
### Description of changes
Added an option to run levels with the lights out with a flashlight helping you to get to the exit.
Added a search mode by holding left CTRL so you can se whats around you without moving when the lights are out.
The game status is now displayed in a status/information bar at the top of the game board, when playing tutorials the information text is now displayed here instead - this fix is closing #8
Updated and added level names, and fixed a game state reset when finishing the last tutorial level.

### Mentions
Persons responsible for reviewing: @CrowStudio
