### PR TITLE
Feature/add flickering light when starting level with lights out

### DIFF
--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -1123,6 +1123,8 @@ def main():
             game_board = pygame.display.set_mode((board.game_board_x, board.game_board_y + board.offset_y))  # Adjust the height
             game_state.new_level = True  # Reset level to start from the selected one
 
+
+
             # Main game loop
             while game_state.is_playing:
                 for event in pygame.event.get():
@@ -1135,6 +1137,10 @@ def main():
                     board.lv = game_state.current_level
                     mode_index = 0 if game_state.game == False else 1
                     game_state.new_level = board.generate_level(game_board, game_state, True, mode_index)
+
+                    # Apply flickering effect if lights are off
+                    if game_state.lights_out:
+                        board.flicker_effect(game_board, game_state, board, screen)
 
                 # Handle input only if not in movement cooldown
                 if game_state.debounce_timer == 0:

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -150,6 +150,7 @@ class HighScores:
             screen.blit(back_text, back_text_center)
 
         pygame.display.flip()
+        pygame.time.wait(300)
 
     # Input box for entering initials after achieving a high score
     def get_initials(self, screen):
@@ -1156,7 +1157,6 @@ def main():
                     if not game_state.is_playing:
                         high_scores.from_start_screen = False  # Set the flag to False
                         high_scores.display_scores(screen)
-                        pygame.time.wait(3000)
                         show_start_screen = True
 
                     # Fade out effect

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -834,11 +834,15 @@ class BoardElements():
     def flicker_effect(self, game_board, game_state, board, screen):
         if self.blackout:
             screen.fill((30, 30, 30))
+            # Status bar
             bar_rect = pygame.Rect(0, board.offset_y - board.offset_y, screen.get_width(), board.offset_y)
             font = pygame.font.SysFont('Lucida Console', 24)  # Font for UI text
             moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
             total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
             lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
+            # Tutorial bar
+            tutorial_font = pygame.font.SysFont('Lucida Console', 12)  # Font for tutorial text
+            tutorial_text = tutorial_font.render(f'{board.map_title[0][game_state.current_level]}', True, (255, 255, 255)) # Set status bar
 
             # Define the base pattern of on/off durations in seconds
             base_pattern = [
@@ -867,11 +871,17 @@ class BoardElements():
                     self.blit_box_4(game_board, 0, 0)
                     self.blit_player(game_board, game_state, 0)  # Assuming 0 as a placeholder for p_move
                     # Render status bar
-                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
-                    game_board.blit(moves_text, (10, 10))
-                    game_board.blit(total_moves_text, (200, 10))
-                    game_board.blit(lives_text, (480, 10))
-                    pygame.display.update()
+                    if game_state.game == True:
+                        pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
+                        pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                        screen.blit(moves_text, (10, 10))
+                        screen.blit(total_moves_text, (200, 10))
+                        screen.blit(lives_text, (480, 10))
+                        pygame.display.update()
+                    else:
+                        pygame.display.set_caption(f'Escape the Werehouse! - Tutorial {game_state.current_level + 1}')
+                        pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                        screen.blit(tutorial_text, (15, 15))
                     time.sleep(on_time)
                     first_iteration = False
                 else:
@@ -887,10 +897,17 @@ class BoardElements():
                     self.blit_player(game_board, game_state, 0)  # Assuming 0 as a placeholder for p_move
                     game_board.blit(mask, (0, 0))
                     # Render status bar
-                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
-                    game_board.blit(moves_text, (10, 10))
-                    game_board.blit(total_moves_text, (200, 10))
-                    game_board.blit(lives_text, (480, 10))
+                    if game_state.game == True:
+                        pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
+                        pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                        screen.blit(moves_text, (10, 10))
+                        screen.blit(total_moves_text, (200, 10))
+                        screen.blit(lives_text, (480, 10))
+                        pygame.display.update()
+                    else:
+                        pygame.display.set_caption(f'Escape the Werehouse! - Tutorial {game_state.current_level + 1}')
+                        pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                        screen.blit(tutorial_text, (15, 15))
                     pygame.display.update()
                     time.sleep(on_time)
 
@@ -905,10 +922,17 @@ class BoardElements():
                 self.blit_box_4(game_board, 0, 0)
                 game_board.blit(mask, (0, 0))
                 # Render status bar
-                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
-                game_board.blit(moves_text, (10, 10))
-                game_board.blit(total_moves_text, (200, 10))
-                game_board.blit(lives_text, (480, 10))
+                if game_state.game == True:
+                    pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
+                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                    screen.blit(moves_text, (10, 10))
+                    screen.blit(total_moves_text, (200, 10))
+                    screen.blit(lives_text, (480, 10))
+                    pygame.display.update()
+                else:
+                    pygame.display.set_caption(f'Escape the Werehouse! - Tutorial {game_state.current_level + 1}')
+                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                    screen.blit(tutorial_text, (15, 15))
                 pygame.display.update()
                 time.sleep(off_time)
 

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -854,7 +854,7 @@ class BoardElements():
             # Loop through the base pattern and apply random variations
             for on_time, off_time in base_pattern:
                 # Apply slight random variations to the on and off times
-                on_time = max(0.01, on_time + random.uniform(-0.05, 0.05))
+                on_time = max(0.015, on_time + random.uniform(-0.05, 0.05))
                 off_time = max(0.01, off_time + random.uniform(-0.05, 0.05))
 
                 if first_iteration:
@@ -913,7 +913,8 @@ class BoardElements():
                 time.sleep(off_time)
 
             # Add a delay before turning on the flashlight beam
-            time.sleep(1)
+            flashligtht_on_delay = 0.7 + random.uniform(-0.2, 0.3)
+            time.sleep(flashligtht_on_delay)
 
             # Turn on the flashlight beam
             self.apply_blackout(game_board, game_state)

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -923,20 +923,57 @@ class BoardElements():
     def fade_out(self, game_state, screen, width, height):
         """Create a fade-out effect."""
         fade = pygame.Surface((width, height))
-        fade.fill((0, 0, 0))
-        for alpha in range(0, 255, 5):  # Increase alpha gradually
+        fade.fill((10, 10, 10))
+
+        if game_state.lights_out:
+            delay = 120
+            start_alpha = 20
+            end_alpha = 180
+            inc_alpha = 10
+            init = 300
+        else:
+            delay = 40
+            start_alpha = 0
+            end_alpha = 180
+            inc_alpha = 10
+            init = 200
+
+        for alpha in range(start_alpha, end_alpha, inc_alpha):  # Increase alpha gradually
             fade.set_alpha(alpha)
             screen.blit(fade, (0, 0))
             pygame.display.update()
-            if game_state.lights_out:
-                pygame.time.wait(40)  # Small delay to control the speed of the fade
-            else:
-                pygame.time.wait(20)  # Small delay to control the speed of the fade
+            if alpha == 0:
+                pygame.time.wait(init)
+            pygame.time.wait(delay)  # Small delay to control the speed of the fade
+
+        if game_state.player_in_pit:
+            # Render the warning text
+            font = pygame.font.SysFont('Arial Black', 42)
+            warning_text = font.render("Watch out for those pits!", True, (220, 0, 10))  # Red text
+            warning_text_rect = warning_text.get_rect(center=(width // 2, 200))
+
+            # Blit the warning text
+            screen.blit(warning_text, warning_text_rect)
+            pygame.display.update()
+
+            # Wait for a moment to let the player read the warning
+            pygame.time.wait(1500)  # Wait for 1.5 seconds
 
     def fade_in(self, screen, width, height, board, game_state):
         """Create a fade-in effect while re-blitting the game board and player."""
+        # Status bar
+        bar_rect = pygame.Rect(0, board.offset_y - board.offset_y, screen.get_width(), board.offset_y)
+        font = pygame.font.SysFont('Lucida Console', 24)  # Font for UI text
+        moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
+        total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
+        lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
+        # Tutorial bar
+        tutorial_font = pygame.font.SysFont('Lucida Console', 12)  # Font for tutorial text
+        tutorial_text = tutorial_font.render(f'{board.map_title[0][game_state.current_level]}', True, (255, 255, 255)) # Set status bar
+
         fade = pygame.Surface((width, height))
-        fade.fill((0, 0, 0))
+        fade.fill((10, 10, 10))
+
         # Decrease alpha gradually from 255 (opaque) to 0 (transparent)
         for alpha in range(255, 0, -10):
             # Re-blit the game state each frame
@@ -948,8 +985,20 @@ class BoardElements():
             board.blit_box_4(screen, 0, 0)
             board.blit_player(screen, game_state, 0)
 
+            if game_state.game == True:
+                pygame.display.set_caption(f'Escape the Werehouse! - {board.map_title[1][game_state.current_level]}')
+                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                screen.blit(moves_text, (10, 10))
+                screen.blit(total_moves_text, (200, 10))
+                screen.blit(lives_text, (480, 10))
+                pygame.display.update()
+            else:
+                pygame.display.set_caption(f'Escape the Werehouse! - Tutorial {game_state.current_level + 1}')
+                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                screen.blit(tutorial_text, (15, 15))
+
             fade.set_alpha(alpha)
             screen.blit(fade, (0, 0))
             pygame.display.update()
-            pygame.time.wait(10)
+            pygame.time.wait(30)
         return

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -1,7 +1,8 @@
 import pygame
-import math
-from random import randrange
 import time
+import math
+import random
+from random import randrange
 from game_board.elements import gfx
 import json
 import os
@@ -829,3 +830,70 @@ class BoardElements():
             pygame.draw.circle(mask, (0, 0, 0, 0), player_center, inner_circle_radius)
             # Finally, blit the mask onto the game board.
             game_board.blit(mask, (0, 0))
+
+    def flicker_effect(self, game_board, game_state, board, screen):
+        if self.blackout:
+            screen.fill((30, 30, 30))
+            bar_rect = pygame.Rect(0, board.offset_y - board.offset_y, screen.get_width(), board.offset_y)
+            font = pygame.font.SysFont('Lucida Console', 24)  # Font for UI text
+            moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
+            total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
+            lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
+            # Define the base pattern of on/off durations in seconds
+            base_pattern = [
+                (0.8, 0.2),
+                (0.15, 0.05),
+                (0.3, 0.05),
+                (0.035, 0.05),
+                (0.015, 0.01)
+            ]
+
+            # Loop through the base pattern and apply random variations
+            for on_time, off_time in base_pattern:
+                # Apply slight random variations to the on and off times
+                on_time = max(0.01, on_time + random.uniform(-0.05, 0.05))
+                off_time = max(0.01, off_time + random.uniform(-0.05, 0.05))
+
+                # Apply the on time with a mask of lower opacity
+                mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
+                mask.fill((0, 0, 0, 76))  # Lower opacity
+                game_board.fill((30, 30, 30))  # Lighter shade
+                self.blit_level(game_board)
+                self.blit_box_1(game_board, 0, 0)
+                self.blit_box_2(game_board, 0, 0)
+                self.blit_box_3(game_board, 0, 0)
+                self.blit_box_4(game_board, 0, 0)
+                self.blit_player(game_board, game_state, 0)  # Assuming 0 as a placeholder for p_move
+                game_board.blit(mask, (0, 0))
+                # Render status bar
+                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                game_board.blit(moves_text, (10, 10))
+                game_board.blit(total_moves_text, (200, 10))
+                game_board.blit(lives_text, (480, 10))
+                pygame.display.update()
+                time.sleep(on_time)
+
+                # Apply the off time with a mask of higher opacity
+                mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
+                mask.fill((0, 0, 0, 249))  # Higher opacity
+                game_board.fill((30, 30, 30))  # Lighter shade
+                self.blit_level(game_board)
+                self.blit_box_1(game_board, 0, 0)
+                self.blit_box_2(game_board, 0, 0)
+                self.blit_box_3(game_board, 0, 0)
+                self.blit_box_4(game_board, 0, 0)
+                game_board.blit(mask, (0, 0))
+                # Render status bar
+                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                game_board.blit(moves_text, (10, 10))
+                game_board.blit(total_moves_text, (200, 10))
+                game_board.blit(lives_text, (480, 10))
+                pygame.display.update()
+                time.sleep(off_time)
+
+            # Add a delay before turning on the flashlight beam
+            time.sleep(1)
+
+            # Turn on the flashlight beam
+            self.apply_blackout(game_board, game_state)
+            pygame.display.update()

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -859,7 +859,7 @@ class BoardElements():
 
                 if first_iteration:
                     # First iteration: no mask
-                    game_board.fill((30, 30, 30))  # Lighter shade
+                    game_board.fill((30, 30, 30))
                     self.blit_level(game_board)
                     self.blit_box_1(game_board, 0, 0)
                     self.blit_box_2(game_board, 0, 0)
@@ -878,7 +878,7 @@ class BoardElements():
                     # Apply the on time with a mask of lower opacity
                     mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
                     mask.fill((0, 0, 0, 76))  # Lower opacity
-                    game_board.fill((30, 30, 30))  # Lighter shade
+                    game_board.fill((30, 30, 30))
                     self.blit_level(game_board)
                     self.blit_box_1(game_board, 0, 0)
                     self.blit_box_2(game_board, 0, 0)
@@ -897,7 +897,7 @@ class BoardElements():
                 # Apply the off time with a mask of higher opacity
                 mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
                 mask.fill((0, 0, 0, 249))  # Higher opacity
-                game_board.fill((30, 30, 30))  # Lighter shade
+                game_board.fill((30, 30, 30))
                 self.blit_level(game_board)
                 self.blit_box_1(game_board, 0, 0)
                 self.blit_box_2(game_board, 0, 0)
@@ -919,3 +919,36 @@ class BoardElements():
             # Turn on the flashlight beam
             self.apply_blackout(game_board, game_state)
             pygame.display.update()
+
+    def fade_out(self, game_state, screen, width, height):
+        """Create a fade-out effect."""
+        fade = pygame.Surface((width, height))
+        fade.fill((0, 0, 0))
+        for alpha in range(0, 255, 5):  # Increase alpha gradually
+            fade.set_alpha(alpha)
+            screen.blit(fade, (0, 0))
+            pygame.display.update()
+            if game_state.lights_out:
+                pygame.time.wait(40)  # Small delay to control the speed of the fade
+            else:
+                pygame.time.wait(20)  # Small delay to control the speed of the fade
+
+    def fade_in(self, screen, width, height, board, game_state):
+        """Create a fade-in effect while re-blitting the game board and player."""
+        fade = pygame.Surface((width, height))
+        fade.fill((0, 0, 0))
+        # Decrease alpha gradually from 255 (opaque) to 0 (transparent)
+        for alpha in range(255, 0, -10):
+            # Re-blit the game state each frame
+            board.blit_level(screen)
+            board.blit_box_1(screen, 0, 0)
+            board.blit_box_2(screen, 0, 0)
+            board.blit_box_3(screen, 0, 0)
+            board.blit_box_4(screen, 0, 0)
+            board.blit_player(screen, game_state, 0)
+
+            fade.set_alpha(alpha)
+            screen.blit(fade, (0, 0))
+            pygame.display.update()
+            pygame.time.wait(10)
+        return

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -940,6 +940,7 @@ class BoardElements():
         # Decrease alpha gradually from 255 (opaque) to 0 (transparent)
         for alpha in range(255, 0, -10):
             # Re-blit the game state each frame
+            screen.fill((30, 30, 30))
             board.blit_level(screen)
             board.blit_box_1(screen, 0, 0)
             board.blit_box_2(screen, 0, 0)

--- a/game_board/blitting.py
+++ b/game_board/blitting.py
@@ -839,6 +839,7 @@ class BoardElements():
             moves_text = font.render(f'Moves: {game_state.moves}', True, (255, 255, 255))
             total_moves_text = font.render(f'Total Moves: {game_state.total_moves}', True, (255, 255, 255))
             lives_text = font.render(f'Lives: {game_state.lives}', True, (255, 255, 255))
+
             # Define the base pattern of on/off durations in seconds
             base_pattern = [
                 (0.8, 0.2),
@@ -848,30 +849,50 @@ class BoardElements():
                 (0.015, 0.01)
             ]
 
+            first_iteration = True  # Flag to track the first iteration
+
             # Loop through the base pattern and apply random variations
             for on_time, off_time in base_pattern:
                 # Apply slight random variations to the on and off times
                 on_time = max(0.01, on_time + random.uniform(-0.05, 0.05))
                 off_time = max(0.01, off_time + random.uniform(-0.05, 0.05))
 
-                # Apply the on time with a mask of lower opacity
-                mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
-                mask.fill((0, 0, 0, 76))  # Lower opacity
-                game_board.fill((30, 30, 30))  # Lighter shade
-                self.blit_level(game_board)
-                self.blit_box_1(game_board, 0, 0)
-                self.blit_box_2(game_board, 0, 0)
-                self.blit_box_3(game_board, 0, 0)
-                self.blit_box_4(game_board, 0, 0)
-                self.blit_player(game_board, game_state, 0)  # Assuming 0 as a placeholder for p_move
-                game_board.blit(mask, (0, 0))
-                # Render status bar
-                pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
-                game_board.blit(moves_text, (10, 10))
-                game_board.blit(total_moves_text, (200, 10))
-                game_board.blit(lives_text, (480, 10))
-                pygame.display.update()
-                time.sleep(on_time)
+                if first_iteration:
+                    # First iteration: no mask
+                    game_board.fill((30, 30, 30))  # Lighter shade
+                    self.blit_level(game_board)
+                    self.blit_box_1(game_board, 0, 0)
+                    self.blit_box_2(game_board, 0, 0)
+                    self.blit_box_3(game_board, 0, 0)
+                    self.blit_box_4(game_board, 0, 0)
+                    self.blit_player(game_board, game_state, 0)  # Assuming 0 as a placeholder for p_move
+                    # Render status bar
+                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                    game_board.blit(moves_text, (10, 10))
+                    game_board.blit(total_moves_text, (200, 10))
+                    game_board.blit(lives_text, (480, 10))
+                    pygame.display.update()
+                    time.sleep(on_time)
+                    first_iteration = False
+                else:
+                    # Apply the on time with a mask of lower opacity
+                    mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)
+                    mask.fill((0, 0, 0, 76))  # Lower opacity
+                    game_board.fill((30, 30, 30))  # Lighter shade
+                    self.blit_level(game_board)
+                    self.blit_box_1(game_board, 0, 0)
+                    self.blit_box_2(game_board, 0, 0)
+                    self.blit_box_3(game_board, 0, 0)
+                    self.blit_box_4(game_board, 0, 0)
+                    self.blit_player(game_board, game_state, 0)  # Assuming 0 as a placeholder for p_move
+                    game_board.blit(mask, (0, 0))
+                    # Render status bar
+                    pygame.draw.rect(screen, (50, 50, 50), bar_rect)  # Dark gray color for the bar
+                    game_board.blit(moves_text, (10, 10))
+                    game_board.blit(total_moves_text, (200, 10))
+                    game_board.blit(lives_text, (480, 10))
+                    pygame.display.update()
+                    time.sleep(on_time)
 
                 # Apply the off time with a mask of higher opacity
                 mask = pygame.Surface((self.game_board_x, self.game_board_y + self.offset_y), pygame.SRCALPHA)


### PR DESCRIPTION
### Reference a related issue

This pull request solves #28

### Description of changes
- Add semi random flickering effect when starting level with lights out.
- Add fade in/out to ease transitions between levels, and when resetting a level.

### Mentions
Persons responsible for reviewing: @CrowStudio
