### PR TITLE
Fix so that basic elements is OK when pulling

### DIFF
--- a/game_board/basic_tile.py
+++ b/game_board/basic_tile.py
@@ -16,3 +16,15 @@ class BasicTile:
     FLOOR       = 6
     WALL        = 7
     EXIT        = 8
+
+    mapping = {
+            START,
+            PIT1,
+            PIT2,
+            PIT3,
+            PIT4,
+            PIT_WALL,
+            FLOOR,
+            WALL,
+            EXIT
+        }

--- a/game_board/zone_level_wrapper.py
+++ b/game_board/zone_level_wrapper.py
@@ -5,5 +5,5 @@ from game_board.zones.zone_2 import ZoneTwo
 class ZoneLevelWrapper:
     def __init__(self):
         self.zones = [ZoneOne(), ZoneTwo()]
-        self.current_zone_index = 0
+        self.current_zone_index = 1
         self.current_zone = self.zones[self.current_zone_index]

--- a/game_board/zone_level_wrapper.py
+++ b/game_board/zone_level_wrapper.py
@@ -5,5 +5,5 @@ from game_board.zones.zone_2 import ZoneTwo
 class ZoneLevelWrapper:
     def __init__(self):
         self.zones = [ZoneOne(), ZoneTwo()]
-        self.current_zone_index = 1
+        self.current_zone_index = 0
         self.current_zone = self.zones[self.current_zone_index]

--- a/game_board/zones/level_maps/zone_2_maps.json
+++ b/game_board/zones/level_maps/zone_2_maps.json
@@ -107,8 +107,8 @@
               [
                 "SLIDING_DOOR_VERTICAL_1_0",
                 "SLIDING_DOOR_VERTICAL_2_0",
-                "FLOOR",
-                "FLOOR",
+                "PIT1",
+                "PIT2",
                 "FLOOR",
                 "START"
               ]

--- a/game_board/zones/zone_1.py
+++ b/game_board/zones/zone_1.py
@@ -16,8 +16,20 @@ class ZoneOne(BasicBoardElements):
     def __init__(self):
         super().__init__(ZONE_DATA)
 
-    def blit_level(self, game_state):
-        super().blit_basic_elements(game_state)
+    def check_zone_element_state(self, element, game_state, player_pos=None, boxes_pos=None):
+        element_type = element[0]
+        # Basic tiles are OK
+        if element_type in self.basic_tile.mapping:
+            return True
 
-    def check_boxes_with_zone_elements(self, game_State, box_num, bx, by):
-        return False
+    def blit_zone_element(self, element, pos, i, game_state):
+        pass
+
+    def blit_level(self, game_state):
+        super().blit_basic_elements(game_state, blit_zone_element = self.blit_zone_element)
+
+    def validate_move(self, new_x, new_y, game_state):
+        return super().validate_move(new_x, new_y, game_state, check_zone_element_state=self.check_zone_element_state)
+
+    def validate_push(self, push_x, push_y, game_state):
+        return super().validate_push(push_x, push_y, game_state, check_zone_element_state=self.check_zone_element_state)

--- a/game_board/zones/zone_2.py
+++ b/game_board/zones/zone_2.py
@@ -123,6 +123,10 @@ class ZoneTwo(BasicBoardElements):
                         print(f'Passing {element_info}')
                         return True
 
+        # Basic tiles are OK
+        if element_type in self.basic_tile.mapping:
+            return True
+
         # Default case: Element not in mapping
         print(f"Warning: Unknown element {element_type} in check_zone_element_state")
         return False


### PR DESCRIPTION
### Behaviour
When pulling a box into a pit the game crashed.

### Expected behavior
When you pulls a box towards an active pit you should fall into the pit and lose one life

### Solution
Add a check for basic tile in method check_for_zone_elements()
- This is now fixed for both levels with unique zone elements and levels with only basic elements.

### Mentions
Persons responsible for reviewing: @CrowStudio
