### PR TITLE
Improvement/make bottomless pit a bottomless pit

### DIFF
--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -263,9 +263,6 @@ def move_player_and_boxes(level, audio, game_state):
         print('Cannot move in that direction!')
         return False  # Don't move if invalid
 
-    # Check if player falls into pit
-    if game_state.check_player_in_pit(new_x, new_y, audio):
-        return False  # Movement was valid but player fell
 
     # Handle box movement
     if game_state.is_pulling:
@@ -296,6 +293,7 @@ def move_player_and_boxes(level, audio, game_state):
             game_state.b1x = new_x + (new_x - x)
             game_state.b1y = new_y + (new_y - y)
             if game_state.check_box_in_pit(1, game_state.b1x, game_state.b1y):
+                audio.play_sound('move')
                 audio.play_sound('fall')
             else:
                 audio.play_sound('move')
@@ -303,6 +301,7 @@ def move_player_and_boxes(level, audio, game_state):
             game_state.b2x = new_x + (new_x - x)
             game_state.b2y = new_y + (new_y - y)
             if game_state.check_box_in_pit(2, game_state.b2x, game_state.b2y):
+                audio.play_sound('move')
                 audio.play_sound('fall')
             else:
                 audio.play_sound('move')
@@ -310,6 +309,7 @@ def move_player_and_boxes(level, audio, game_state):
             game_state.b3x = new_x + (new_x - x)
             game_state.b3y = new_y + (new_y - y)
             if game_state.check_box_in_pit(3, game_state.b3x, game_state.b3y):
+                audio.play_sound('move')
                 audio.play_sound('fall')
             else:
                 audio.play_sound('move')
@@ -317,16 +317,21 @@ def move_player_and_boxes(level, audio, game_state):
             game_state.b4x = new_x + (new_x - x)
             game_state.b4y = new_y + (new_y - y)
             if game_state.check_box_in_pit(4, game_state.b4x, game_state.b4y):
+                audio.play_sound('move')
                 audio.play_sound('fall')
             else:
                 audio.play_sound('move')
 
-    # Move player to new position
-    print('Moving')
-    game_state.px = new_x
-    game_state.py = new_y
+    # Check if player falls into pit
+    if game_state.check_player_in_pit(new_x, new_y, audio):
+        return False  # Movement was valid but player fell
 
-    return True
+    else:  # Move player to new position
+        print('Moving')
+        game_state.px = new_x
+        game_state.py = new_y
+
+        return True
 
 
 def main():

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -263,7 +263,6 @@ def move_player_and_boxes(level, audio, game_state):
         print('Cannot move in that direction!')
         return False  # Don't move if invalid
 
-
     # Handle box movement
     if game_state.is_pulling:
         # Calculate position behind player

--- a/escape_the_werehouse.py
+++ b/escape_the_werehouse.py
@@ -377,6 +377,7 @@ def main():
                 if game_state.new_level:
                     zone.current_level_set.level_index = game_state.current_level
                     mode_index = 0 if game_state.game == False else 1  # Check if it is tutorial level or game level
+                    game_state.initialize_zone_elements()
                     zone.current_level_set.game_board.fill((30, 30, 30))
                     game_state.new_level = zone.current_level_set.generate_level(game_state, True, mode_index)
                     game_state.player_in_pit = False # Reset player

--- a/game_board/blitter.py
+++ b/game_board/blitter.py
@@ -88,7 +88,7 @@ class Blitter():
         self.__pit_common__(game_state, pos, box, 4,  eye_index=i)
 
     # Blit pit_as_wall tile
-    def __pit_as_wall__(self, pos):
+    def __bottomless_pit__(self, pos):
         # identical to a “dead” pit
         self.game_board.blit(Sprite.PIT, pos)
 
@@ -186,7 +186,7 @@ class Blitter():
             101020102: (self.__pit_2__, 'in_pit2'),
             101030103: (self.__pit_3__, 'in_pit3'),
             101040104: (self.__pit_4__, 'in_pit4'),
-            101050005: (self.__pit_as_wall__, None),
+            101050005: (self.__bottomless_pit__, None),
             101060006: (self.__floor__, 'floor'),
             101070007: (self.__wall__, None),
             101080108: (self.__exit__, 'exit'),

--- a/game_board/blitter.py
+++ b/game_board/blitter.py
@@ -87,7 +87,7 @@ class Blitter():
     def __pit_4__(self, pos, box, i, game_state):
         self.__pit_common__(game_state, pos, box, 4,  eye_index=i)
 
-    # Blit pit_as_wall tile
+    # Blit pit tile
     def __bottomless_pit__(self, pos):
         # identical to a “dead” pit
         self.game_board.blit(Sprite.PIT, pos)

--- a/game_board/zone_level_wrapper.py
+++ b/game_board/zone_level_wrapper.py
@@ -6,7 +6,7 @@ class ZoneLevelWrapper:
     def __init__(self):
         self.zone = [ZoneOne(), ZoneTwo()]
         self.no_of_zones = len(self.zone) -1  # to compensate for zone index that starts at 0
-        self.current_zone_index = 1
+        self.current_zone_index = 0
         self.current_level_set = self.zone[self.current_zone_index]
 
     def switch_to_next_zone(self):

--- a/game_board/zone_level_wrapper.py
+++ b/game_board/zone_level_wrapper.py
@@ -6,7 +6,7 @@ class ZoneLevelWrapper:
     def __init__(self):
         self.zone = [ZoneOne(), ZoneTwo()]
         self.no_of_zones = len(self.zone) -1  # to compensate for zone index that starts at 0
-        self.current_zone_index = 0
+        self.current_zone_index = 1
         self.current_level_set = self.zone[self.current_zone_index]
 
     def switch_to_next_zone(self):

--- a/game_board/zones/level_maps/zone_2_maps.json
+++ b/game_board/zones/level_maps/zone_2_maps.json
@@ -62,140 +62,55 @@
     "levels": [
         {
             "level": 1,
-            "title": "Trip Trap Doors",
-            "map": [
-              [
-                "FLOOR_SWITCH_2_1",
-                "FLOOR",
-                "FLOOR",
-                "FLOOR",
-                "FLOOR",
-                "FLOOR"
-              ],
-              [
-                "WALL",
-                "SLIDING_DOOR_HORIZONTAL_3_1",
-                "WALL",
-                "FLOOR",
-                "FLOOR",
-                "FLOOR"
-              ],
-              [
-                "WALL_SWITCH_LEFT_2_0",
-                "FLOOR",
-                "FLOOR",
-                "WALL",
-                "FLOOR",
-                "FLOOR"
-              ],
-              [
-                "WALL",
-                "WALL",
-                "TRAP_DOOR_UP_1_1",
-                "WALL",
-                "FLOOR",
-                "FLOOR_SWITCH_3_0"
-              ],
-              [
-                "FLOOR",
-                "FLOOR_SWITCH_1_1",
-                "FLOOR",
-                "WALL",
-                "TRAP_DOOR_DOWN_1_1",
-                "FLOOR"
-              ],
-              [
-                "WALL",
-                "START",
-                "WALL",
-                "EXIT",
-                "TRAP_DOOR_LEFT_1_0",
-                "FLOOR"
-              ]
-            ],
-            "active_boxes": [
-                true,
-                true,
-                true,
-                true
-            ],
-            "box_positions": [
-                [
-                    0,
-                    4
-                ],
-                [
-                    1,
-                    2
-                ],
-                [
-                    5,
-                    0
-                ],
-                [
-                    5,
-                    3
-                ]
-            ],
-            "player_start": [
-                1,
-                5
-            ],
-            "player_direction": "up",
-            "exit_active": true,
-            "score": 32
-        },
-        {
-            "level": 2,
-            "title": "Blocked 2",
+            "title": "DEV MAP",
           "map": [
             [
-              "FLOOR",
-              "FLOOR",
-              "WALL_SWITCH_RIGHT_1_1",
               "WALL",
+              "WALL",
+              "WALL",
+              "WALL",
+              "WALL",
+              "WALL"
+            ],
+            [
               "EXIT",
-              "TRAP_DOOR_UP_1_1"
+              "FLOOR",
+              "FLOOR",
+              "FLOOR",
+              "FLOOR",
+              "FLOOR"
             ],
             [
               "PIT1",
-              "WALL",
-              "WALL",
-              "WALL",
-              "WALL",
-              "SLIDING_DOOR_HORIZONTAL_2_1"
+              "BOTTOMLESS_PIT",
+              "BOTTOMLESS_PIT",
+              "BOTTOMLESS_PIT",
+              "BOTTOMLESS_PIT",
+              "BOTTOMLESS_PIT"
             ],
             [
               "FLOOR",
-              "SLIDING_DOOR_VERTICAL_4_0",
               "FLOOR",
               "FLOOR",
               "FLOOR",
-              "PIT4"
+              "FLOOR",
+              "FLOOR"
             ],
             [
               "FLOOR",
-              "WALL",
               "FLOOR",
               "FLOOR",
-              "FLOOR_SWITCH_1_1",
-              "WALL"
-            ],
-            [
-              "FLOOR",
-              "WALL",
               "FLOOR",
               "FLOOR",
-              "WALL",
-              "WALL"
+              "FLOOR"
             ],
             [
               "START",
-              "WALL",
-              "WALL",
-              "WALL_SWITCH_DOWN_1_0",
-              "WALL",
-              "WALL"
+              "FLOOR",
+              "FLOOR",
+              "FLOOR",
+              "FLOOR",
+              "FLOOR"
             ]
           ],
             "active_boxes": [
@@ -207,19 +122,19 @@
             "box_positions": [
                 [
                     0,
-                    4
+                    3
+                ],
+                [
+                    1,
+                    3
+                ],
+                [
+                    2,
+                    3
                 ],
                 [
                     3,
-                    4
-                ],
-                [
-                    3,
-                    2
-                ],
-                [
-                    4,
-                    2
+                    3
                 ]
             ],
             "player_start": [
@@ -230,7 +145,92 @@
             "exit_active": true,
             "score": 29
         },
-        {
+      {
+        "level": 2,
+        "title": "Trip Trap Doors",
+        "map": [
+          [
+            "FLOOR_SWITCH_2_1",
+            "FLOOR",
+            "FLOOR",
+            "FLOOR",
+            "FLOOR",
+            "FLOOR"
+          ],
+          [
+            "WALL",
+            "SLIDING_DOOR_HORIZONTAL_3_1",
+            "WALL",
+            "FLOOR",
+            "FLOOR",
+            "FLOOR"
+          ],
+          [
+            "WALL_SWITCH_LEFT_2_0",
+            "FLOOR",
+            "FLOOR",
+            "WALL",
+            "FLOOR",
+            "BOTTOMLESS_PIT"
+          ],
+          [
+            "WALL",
+            "WALL",
+            "TRAP_DOOR_UP_1_1",
+            "WALL",
+            "FLOOR",
+            "FLOOR_SWITCH_3_0"
+          ],
+          [
+            "FLOOR",
+            "FLOOR_SWITCH_1_1",
+            "FLOOR",
+            "WALL",
+            "TRAP_DOOR_DOWN_1_1",
+            "FLOOR"
+          ],
+          [
+            "WALL",
+            "START",
+            "WALL",
+            "EXIT",
+            "TRAP_DOOR_LEFT_1_0",
+            "FLOOR"
+          ]
+        ],
+        "active_boxes": [
+          true,
+          true,
+          true,
+          true
+        ],
+        "box_positions": [
+          [
+            0,
+            4
+          ],
+          [
+            1,
+            2
+          ],
+          [
+            5,
+            0
+          ],
+          [
+            5,
+            3
+          ]
+        ],
+        "player_start": [
+          1,
+          5
+        ],
+        "player_direction": "up",
+        "exit_active": true,
+        "score": 32
+      },
+      {
             "level": 3,
             "title": "Deceiving Pits 2",
             "map": [


### PR DESCRIPTION
### Reference a related issue

This pull request solves #48 and #51

### Description of changes
- Make BOTTOMLESS_PIT (old PIT_WALL) to act as a pit instead of a wall so player or box can fall into it
- Solve bug connected to box not moving towards pit when player pulls box towards pit and fall into it.
  - Add moving sound before box falls into pit sound.

### Mentions
Persons responsible for reviewing: @CrowStudio
